### PR TITLE
Require o3 compatible openai package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langchain-community>=0.3.9",
     "langchain-openai>=0.3.3",
     "langchain-anthropic>=0.3.3",
+    "openai>=1.61.0",
     "tavily-python>=0.5.0",
 ]
 


### PR DESCRIPTION
I tried to apply some of these concepts in an existing project, and I couldn't create an `o3-mini` llm instance using ChatOpenAI. 

I figured my project used an outdated `openai` that didn't support `o3-mini`.

Thus I suggest we specify a compatible version of `openai` in `pyproejct.toml`.