### PR TITLE
Fix feedback state

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -35,7 +35,7 @@ class Configuration:
     report_structure: str = DEFAULT_REPORT_STRUCTURE # Defaults to the default report structure
     number_of_queries: int = 2 # Number of search queries to generate per iteration
     max_search_depth: int = 2 # Maximum number of reflection + search iterations
-    planner_provider: PlannerProvider = PlannerProvider.ANTHROPIC # Defaults to OpenAI as provider
+    planner_provider: PlannerProvider = PlannerProvider.OPENAI  # Defaults to OpenAI as provider
     planner_model: str = "o3-mini" # Defaults to OpenAI o3-mini as planner model
     writer_provider: WriterProvider = WriterProvider.ANTHROPIC # Defaults to Anthropic as provider
     writer_model: str = "claude-3-5-sonnet-latest" # Defaults to Anthropic as provider

--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -26,14 +26,18 @@ class PlannerProvider(Enum):
     OPENAI = "openai"
     GROQ = "groq"
 
+class WriterProvider(Enum):
+    ANTHROPIC = "anthropic"
+
 @dataclass(kw_only=True)
 class Configuration:
     """The configurable fields for the chatbot."""
     report_structure: str = DEFAULT_REPORT_STRUCTURE # Defaults to the default report structure
     number_of_queries: int = 2 # Number of search queries to generate per iteration
     max_search_depth: int = 2 # Maximum number of reflection + search iterations
-    planner_provider: PlannerProvider = PlannerProvider.OPENAI # Defaults to OpenAI as provider
+    planner_provider: PlannerProvider = PlannerProvider.ANTHROPIC # Defaults to OpenAI as provider
     planner_model: str = "o3-mini" # Defaults to OpenAI o3-mini as planner model
+    writer_provider: WriterProvider = WriterProvider.ANTHROPIC # Defaults to Anthropic as provider
     writer_model: str = "claude-3-5-sonnet-latest" # Defaults to Anthropic as provider
     search_api: SearchAPI = SearchAPI.TAVILY # Default to TAVILY
 

--- a/src/open_deep_research/state.py
+++ b/src/open_deep_research/state.py
@@ -46,6 +46,7 @@ class ReportStateOutput(TypedDict):
 class ReportState(TypedDict):
     topic: str # Report topic    
     sections: list[Section] # List of report sections 
+    feedback_on_report_plan: str # Feedback on the report plan
     completed_sections: Annotated[list, operator.add] # Send() API key
     report_sections_from_research: str # String of any completed sections from research to write final sections
     final_report: str # Final report
@@ -55,7 +56,6 @@ class SectionState(TypedDict):
     search_iterations: int # Number of search iterations done
     search_queries: list[SearchQuery] # List of search queries
     source_str: str # String of formatted source content from web search
-    feedback_on_report_plan: str # Feedback on the report plan
     report_sections_from_research: str # String of any completed sections from research to write final sections
     completed_sections: list[Section] # Final key we duplicate in outer state for Send() API
 


### PR DESCRIPTION
The feedback of the generate_report_plan function became None even after the transition after executing human_feedback.

After investigating, I found that feedback_on_report_plan is required in ReportState, but it was present in SectionState.