### PR TITLE
Fix_feedback_state

### DIFF
--- a/src/open_deep_research/state.py
+++ b/src/open_deep_research/state.py
@@ -45,6 +45,7 @@ class ReportStateOutput(TypedDict):
 
 class ReportState(TypedDict):
     topic: str # Report topic    
+    feedback_on_report_plan: str # Feedback on the report plan
     sections: list[Section] # List of report sections 
     completed_sections: Annotated[list, operator.add] # Send() API key
     report_sections_from_research: str # String of any completed sections from research to write final sections
@@ -55,7 +56,6 @@ class SectionState(TypedDict):
     search_iterations: int # Number of search iterations done
     search_queries: list[SearchQuery] # List of search queries
     source_str: str # String of formatted source content from web search
-    feedback_on_report_plan: str # Feedback on the report plan
     report_sections_from_research: str # String of any completed sections from research to write final sections
     completed_sections: list[Section] # Final key we duplicate in outer state for Send() API
 


### PR DESCRIPTION
The feedback of the generate_report_plan function became None even after the transition after executing human_feedback.

After investigating, I found that feedback_on_report_plan is required in ReportState, but it was present in SectionState.