### PR TITLE
fix(configuration): make writer_provider configurable

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -25,9 +25,12 @@ class SearchAPI(Enum):
 class PlannerProvider(Enum):
     OPENAI = "openai"
     GROQ = "groq"
+    ANTHROPIC = "antrhopic"
 
 class WriterProvider(Enum):
     ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GROQ = "groq"
 
 @dataclass(kw_only=True)
 class Configuration:
@@ -36,7 +39,7 @@ class Configuration:
     number_of_queries: int = 2 # Number of search queries to generate per iteration
     max_search_depth: int = 2 # Maximum number of reflection + search iterations
     planner_provider: PlannerProvider = PlannerProvider.OPENAI  # Defaults to OpenAI as provider
-    planner_model: str = "o3-mini" # Defaults to OpenAI o3-mini as planner model
+    planner_model: str = "gpt-4o-mini" # Defaults to OpenAI o3-mini as planner model
     writer_provider: WriterProvider = WriterProvider.ANTHROPIC # Defaults to Anthropic as provider
     writer_model: str = "claude-3-5-sonnet-latest" # Defaults to Anthropic as provider
     search_api: SearchAPI = SearchAPI.TAVILY # Default to TAVILY
@@ -54,4 +57,5 @@ class Configuration:
             for f in fields(cls)
             if f.init
         }
+
         return cls(**{k: v for k, v in values.items() if v})

--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -25,7 +25,7 @@ class SearchAPI(Enum):
 class PlannerProvider(Enum):
     OPENAI = "openai"
     GROQ = "groq"
-    ANTHROPIC = "antrhopic"
+    ANTHROPIC = "anthropic"
 
 class WriterProvider(Enum):
     ANTHROPIC = "anthropic"
@@ -39,7 +39,7 @@ class Configuration:
     number_of_queries: int = 2 # Number of search queries to generate per iteration
     max_search_depth: int = 2 # Maximum number of reflection + search iterations
     planner_provider: PlannerProvider = PlannerProvider.OPENAI  # Defaults to OpenAI as provider
-    planner_model: str = "gpt-4o-mini" # Defaults to OpenAI o3-mini as planner model
+    planner_model: str = "o3-mini" # Defaults to OpenAI o3-mini as planner model
     writer_provider: WriterProvider = WriterProvider.ANTHROPIC # Defaults to Anthropic as provider
     writer_model: str = "claude-3-5-sonnet-latest" # Defaults to Anthropic as provider
     search_api: SearchAPI = SearchAPI.TAVILY # Default to TAVILY


### PR DESCRIPTION
Under previous structure, LLMs weren't fully configurable because there was a mix of reading from the `config` object passed in and the defaults of the `Configuration` object.

`writer_model` was being initialized at the top of `graph.py` before a configuration was created. It was using defaults from the Configuration class, rather than takinga config object. This makes it so `writer_model` is initialized where needed (probably could be factored out). In addition, it fixes a similar instance of a bug with `planner_model`.