### PR TITLE
Add googlesearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available search tools:
 * [PubMed](https://pubmed.ncbi.nlm.nih.gov/) - Biomedical literature from MEDLINE, life science journals, and online books
 * [Linkup API](https://www.linkup.so/) - General web search
 * [DuckDuckGo API](https://duckduckgo.com/) - General web search
+* [Google Search API/Scrapper](https://google.com/) - General web search
 
 Open Deep Research uses a planner LLM for report planning and a writer LLM for report writing: 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "linkup-sdk>=0.2.3",
     "duckduckgo-search>=3.0.0",
     "exa-py>=1.8.8",
+    "requests>=2.32.3",
+    "beautifulsoup4==4.13.3"
 ]
 
 [project.optional-dependencies]

--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -27,6 +27,7 @@ class SearchAPI(Enum):
     PUBMED = "pubmed"
     LINKUP = "linkup"
     DUCKDUCKGO = "duckduckgo"
+    GOOGLESEARCH = "googlesearch"
 
 @dataclass(kw_only=True)
 class Configuration:

--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -1,19 +1,26 @@
 import os
 import asyncio
 import requests
-from typing import List, Optional, Dict, Any
+import random 
+import concurrent
+import aiohttp
+import time
+import logging
+from typing import List, Optional, Dict, Any, Union
+from urllib.parse import unquote
 
 from exa_py import Exa
 from linkup import LinkupClient
 from tavily import AsyncTavilyClient
+from duckduckgo_search import DDGS 
+from bs4 import BeautifulSoup
 
 from langchain_community.retrievers import ArxivRetriever
 from langchain_community.utilities.pubmed import PubMedAPIWrapper
 from langsmith import traceable
 
 from open_deep_research.state import Section
-from duckduckgo_search import DDGS 
-import logging
+
 
 def get_config_value(value):
     """
@@ -857,6 +864,270 @@ async def duckduckgo_search(search_queries):
     search_docs = await asyncio.gather(*tasks)
     
     return search_docs
+
+@traceable
+async def google_search_async(search_queries: Union[str, List[str]], max_results: int = 5, include_raw_content: bool = True):
+    """
+    Performs concurrent web searches using Google.
+    Uses Google Custom Search API if environment variables are set, otherwise falls back to web scraping.
+
+    Args:
+        search_queries (List[str]): List of search queries to process
+        max_results (int): Maximum number of results to return per query
+        include_raw_content (bool): Whether to fetch full page content
+
+    Returns:
+        List[dict]: List of search responses from Google, one per query
+    """
+
+
+    # Check for API credentials from environment variables
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    cx = os.environ.get("GOOGLE_CX")
+    use_api = bool(api_key and cx)
+    
+    # Handle case where search_queries is a single string
+    if isinstance(search_queries, str):
+        search_queries = [search_queries]
+    
+    # Define user agent generator
+    def get_useragent():
+        """Generates a random user agent string."""
+        lynx_version = f"Lynx/{random.randint(2, 3)}.{random.randint(8, 9)}.{random.randint(0, 2)}"
+        libwww_version = f"libwww-FM/{random.randint(2, 3)}.{random.randint(13, 15)}"
+        ssl_mm_version = f"SSL-MM/{random.randint(1, 2)}.{random.randint(3, 5)}"
+        openssl_version = f"OpenSSL/{random.randint(1, 3)}.{random.randint(0, 4)}.{random.randint(0, 9)}"
+        return f"{lynx_version} {libwww_version} {ssl_mm_version} {openssl_version}"
+    
+    # Create executor for running synchronous operations
+    executor = None if use_api else concurrent.futures.ThreadPoolExecutor(max_workers=5)
+    
+    # Use a semaphore to limit concurrent requests
+    semaphore = asyncio.Semaphore(5 if use_api else 2)
+    
+    async def search_single_query(query):
+        async with semaphore:
+            try:
+                results = []
+                
+                # API-based search
+                if use_api:
+                    # The API returns up to 10 results per request
+                    for start_index in range(1, max_results + 1, 10):
+                        # Calculate how many results to request in this batch
+                        num = min(10, max_results - (start_index - 1))
+                        
+                        # Make request to Google Custom Search API
+                        params = {
+                            'q': query,
+                            'key': api_key,
+                            'cx': cx,
+                            'start': start_index,
+                            'num': num
+                        }
+                        print(f"Requesting {num} results for '{query}' from Google API...")
+
+                        async with aiohttp.ClientSession() as session:
+                            async with session.get('https://www.googleapis.com/customsearch/v1', params=params) as response:
+                                if response.status != 200:
+                                    error_text = await response.text()
+                                    print(f"API error: {response.status}, {error_text}")
+                                    break
+                                    
+                                data = await response.json()
+                                
+                                # Process search results
+                                for item in data.get('items', []):
+                                    result = {
+                                        "title": item.get('title', ''),
+                                        "url": item.get('link', ''),
+                                        "content": item.get('snippet', ''),
+                                        "score": None,
+                                        "raw_content": item.get('snippet', '')
+                                    }
+                                    results.append(result)
+                        
+                        # Respect API quota with a small delay
+                        await asyncio.sleep(0.2)
+                        
+                        # If we didn't get a full page of results, no need to request more
+                        if not data.get('items') or len(data.get('items', [])) < num:
+                            break
+                
+                # Web scraping based search
+                else:
+                    # Add delay between requests
+                    await asyncio.sleep(0.5 + random.random() * 1.5)
+                    print(f"Scraping Google for '{query}'...")
+
+                    # Define scraping function
+                    def google_search(query, max_results):
+                        try:
+                            lang = "en"
+                            safe = "active"
+                            start = 0
+                            fetched_results = 0
+                            fetched_links = set()
+                            search_results = []
+                            
+                            while fetched_results < max_results:
+                                # Send request to Google
+                                resp = requests.get(
+                                    url="https://www.google.com/search",
+                                    headers={
+                                        "User-Agent": get_useragent(),
+                                        "Accept": "*/*"
+                                    },
+                                    params={
+                                        "q": query,
+                                        "num": max_results + 2,
+                                        "hl": lang,
+                                        "start": start,
+                                        "safe": safe,
+                                    },
+                                    cookies = {
+                                        'CONSENT': 'PENDING+987',  # Bypasses the consent page
+                                        'SOCS': 'CAESHAgBEhIaAB',
+                                    }
+                                )
+                                resp.raise_for_status()
+                                
+                                # Parse results
+                                soup = BeautifulSoup(resp.text, "html.parser")
+                                result_block = soup.find_all("div", class_="ezO2md")
+                                new_results = 0
+                                
+                                for result in result_block:
+                                    link_tag = result.find("a", href=True)
+                                    title_tag = link_tag.find("span", class_="CVA68e") if link_tag else None
+                                    description_tag = result.find("span", class_="FrIlee")
+                                    
+                                    if link_tag and title_tag and description_tag:
+                                        link = unquote(link_tag["href"].split("&")[0].replace("/url?q=", ""))
+                                        
+                                        if link in fetched_links:
+                                            continue
+                                        
+                                        fetched_links.add(link)
+                                        title = title_tag.text
+                                        description = description_tag.text
+                                        
+                                        # Store result in the same format as the API results
+                                        search_results.append({
+                                            "title": title,
+                                            "url": link,
+                                            "content": description,
+                                            "score": None,
+                                            "raw_content": description
+                                        })
+                                        
+                                        fetched_results += 1
+                                        new_results += 1
+                                        
+                                        if fetched_results >= max_results:
+                                            break
+                                
+                                if new_results == 0:
+                                    break
+                                    
+                                start += 10
+                                time.sleep(1)  # Delay between pages
+                            
+                            return search_results
+                                
+                        except Exception as e:
+                            print(f"Error in Google search for '{query}': {str(e)}")
+                            return []
+                    
+                    # Execute search in thread pool
+                    loop = asyncio.get_running_loop()
+                    search_results = await loop.run_in_executor(
+                        executor, 
+                        lambda: google_search(query, max_results)
+                    )
+                    
+                    # Process the results
+                    results = search_results
+                
+                # If requested, fetch full page content asynchronously (for both API and web scraping)
+                if include_raw_content and results:
+                    content_semaphore = asyncio.Semaphore(3)
+                    
+                    async with aiohttp.ClientSession() as session:
+                        fetch_tasks = []
+                        
+                        async def fetch_full_content(result):
+                            async with content_semaphore:
+                                url = result['url']
+                                headers = {
+                                    'User-Agent': get_useragent(),
+                                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+                                }
+                                
+                                try:
+                                    await asyncio.sleep(0.2 + random.random() * 0.6)
+                                    async with session.get(url, headers=headers, timeout=10) as response:
+                                        if response.status == 200:
+                                            # Check content type to handle binary files
+                                            content_type = response.headers.get('Content-Type', '').lower()
+                                            
+                                            # Handle PDFs and other binary files
+                                            if 'application/pdf' in content_type or 'application/octet-stream' in content_type:
+                                                # For PDFs, indicate that content is binary and not parsed
+                                                result['raw_content'] = f"[Binary content: {content_type}. Content extraction not supported for this file type.]"
+                                            else:
+                                                try:
+                                                    # Try to decode as UTF-8 with replacements for non-UTF8 characters
+                                                    html = await response.text(errors='replace')
+                                                    soup = BeautifulSoup(html, 'html.parser')
+                                                    result['raw_content'] = soup.get_text()
+                                                except UnicodeDecodeError as ude:
+                                                    # Fallback if we still have decoding issues
+                                                    result['raw_content'] = f"[Could not decode content: {str(ude)}]"
+                                except Exception as e:
+                                    print(f"Warning: Failed to fetch content for {url}: {str(e)}")
+                                    result['raw_content'] = f"[Error fetching content: {str(e)}]"
+                                return result
+                        
+                        for result in results:
+                            fetch_tasks.append(fetch_full_content(result))
+                        
+                        updated_results = await asyncio.gather(*fetch_tasks)
+                        results = updated_results
+                        print(f"Fetched full content for {len(results)} results")
+                
+                return {
+                    "query": query,
+                    "follow_up_questions": None,
+                    "answer": None,
+                    "images": [],
+                    "results": results
+                }
+            except Exception as e:
+                print(f"Error in Google search for query '{query}': {str(e)}")
+                return {
+                    "query": query,
+                    "follow_up_questions": None,
+                    "answer": None,
+                    "images": [],
+                    "results": []
+                }
+    
+    try:
+        # Create tasks for all search queries
+        search_tasks = [search_single_query(query) for query in search_queries]
+        
+        # Execute all searches concurrently
+        search_results = await asyncio.gather(*search_tasks)
+        
+        return search_results
+    finally:
+        # Only shut down executor if it was created
+        if executor:
+            executor.shutdown(wait=False)
+
+
+
 async def select_and_execute_search(search_api: str, query_list: list[str], params_to_pass: dict) -> str:
     """Select and execute the appropriate search API.
     
@@ -891,6 +1162,9 @@ async def select_and_execute_search(search_api: str, query_list: list[str], para
         return deduplicate_and_format_sources(search_results, max_tokens_per_source=4000)
     elif search_api == "duckduckgo":
         search_results = await duckduckgo_search(query_list)
+        return deduplicate_and_format_sources(search_results, max_tokens_per_source=4000)
+    elif search_api == "googlesearch":
+        search_results = await google_search_async(query_list, **params_to_pass)
         return deduplicate_and_format_sources(search_results, max_tokens_per_source=4000)
     else:
         raise ValueError(f"Unsupported search API: {search_api}")


### PR DESCRIPTION
Uses Google Custom Search JSON API if credentials are provided via environment variables, falls back to web scraping with anti-blocking measures if credentials aren't available.

If you want to use the Google API (recommended for reliability):

1. Create a Custom Search Engine at https://programmablesearchengine.google.com/controlpanel/all
2. In overview, check your Search engine ID (CX)
3. Get an API key from https://developers.google.com/custom-search/v1/introduction
4. Set environment variables:
```
GOOGLE_API_KEY="your-api-key"
GOOGLE_CX="your-custom-search-engine-id"
```

**Notes**
- Google's Custom Search API has a free tier with 100 searches per day
- Web scraping fallback should be used sparingly to avoid IP blocking