### PR TITLE
fix: required python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "langgraph>=0.2.55",
     "langchain-community>=0.3.9",


### PR DESCRIPTION
The required version 3.9 will not work because [the Configuration class uses kw_only](https://github.com/langchain-ai/open_deep_research/blob/7c379a21a44c44403d5d8f0db649d4af4a7fe539/src/open_deep_research/configuration.py#L32) which was added in python 3.10.

Additionally, [3.9 will go out of support in october 2025](https://peps.python.org/pep-0596/#lifespan)