### PR TITLE
Disable to load configurations from environment variables

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -62,7 +62,7 @@ class Configuration:
             config["configurable"] if config and "configurable" in config else {}
         )
         values: dict[str, Any] = {
-            f.name: os.environ.get(f.name.upper(), configurable.get(f.name))
+            f.name: configurable.get(f.name)
             for f in fields(cls)
             if f.init
         }


### PR DESCRIPTION
I encountered the error below when I run open_deep_research in GitHub Actions, though I didn't see the issue on my local machine wit the same set up with uv. I haven't completely understand why that happend in an python environment in GitHub Actions. But, `os.environ.get` returns a string if the corresponding environment variable exists. 

We can also technically dynamically cast fields based on the field metadata. However, that can get hacky.  So, I suppose we disable to load configurations of the graph from environment environment variables, as that aren't documented well.

https://github.com/langchain-ai/open_deep_research/blob/a96d33331d9b6df35cc9f3199b9f147ecf5978d4/src/open_deep_research/configuration.py#L65

## Error Message

```shell
  File "/home/runner/work/open-deep-researcher/open-deep-researcher/src/deep_researcher/deep_research.py", line 138, in arun
    async for event in graph.astream(
  File "/home/runner/work/open-deep-researcher/open-deep-researcher/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2732, in astream
    async for _ in runner.atick(
  File "/home/runner/work/open-deep-researcher/open-deep-researcher/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2850, in ainvoke
    async for chunk in self.astream(
  File "/home/runner/work/open-deep-researcher/open-deep-researcher/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2732, in astream
    async for _ in runner.atick(
  File "/home/runner/work/open-deep-researcher/open-deep-researcher/.venv/lib/python3.12/site-packages/open_deep_research/graph.py", line 330, in write_section
    if feedback.grade == "pass" or state["search_iterations"] >= configurable.max_search_depth:
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'int' and 'str'
```