### PR TITLE
Add max_results params for google search api

### DIFF
--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -54,6 +54,7 @@ def get_search_params(search_api: str, search_api_config: Optional[Dict[str, Any
         "arxiv": ["load_max_docs", "get_full_documents", "load_all_available_meta"],
         "pubmed": ["top_k_results", "email", "api_key", "doc_content_chars_max"],
         "linkup": ["depth"],
+        "googlesearch": ["max_results"],
     }
 
     # Get the list of accepted parameters for the given search API


### PR DESCRIPTION
Hi, me again annoying with parameters for the search apis. :D

This PR adds the posibility to make `max_results` configurable for google search api. The scaffolding was already done, it was only missing in the dictionary of accepted parameters for google.