### PR TITLE
Support dotenv versions above 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests>=2.32.3",
     "beautifulsoup4==4.13.3",
     "langchain-deepseek>=0.1.2",
-    "python-dotenv==1.0.1",
+    "python-dotenv>=1.0.1",
     "langgraph_supervisor",
     "langchain_tavily",
     "pytest",


### PR DESCRIPTION
python-dotenv is currently pinned to version 1.0.1. This makes it incompatible to use with fastmcp>=2.2.2 which depends on python-dotenv>=1.1.0
