### PR TITLE
Fixed typo in DEFAULT_REPORT_STRUCTURE

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -16,7 +16,7 @@ DEFAULT_REPORT_STRUCTURE = """Use this structure to create a report on the user-
    - Each section should focus on a sub-topic of the user-provided topic
    
 3. Conclusion
-   - Aim for 1 structural element (either a list of table) that distills the main body sections 
+   - Aim for 1 structural element (either a list or table) that distills the main body sections 
    - Provide a concise summary of the report"""
 
 class SearchAPI(Enum):


### PR DESCRIPTION
Changed "either a list of table" to "either a list or table" on line 19 of configuration.py