### PR TITLE
feat: Add script for programmatic research execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ tmp/
 temp/
 
 .langgraph_api
+final_report.md

--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ python tests/run_evaluate.py
 
 Follow the [quickstart](#-quickstart) to start LangGraph server locally and test the agent out on LangGraph Studio.
 
+#### Command-Line Usage
+
+To run the research process programmatically and save the final report to a file, you can use the `run_research.py` script.
+
+```bash
+python run_research.py "Your research query here"
+```
+
+This will create a `final_report.md` file in the root directory with the output.
+
 #### Hosted deployment
  
 You can easily deploy to [LangGraph Platform](https://langchain-ai.github.io/langgraph/concepts/#deployment-options). 

--- a/run_research.py
+++ b/run_research.py
@@ -1,0 +1,37 @@
+import sys
+import os
+import asyncio
+import argparse
+
+# Add the src directory to the Python path before other imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'src')))
+
+from langchain_core.messages import HumanMessage
+from open_deep_research.deep_researcher import deep_researcher
+
+async def main():
+    parser = argparse.ArgumentParser(description="Run the deep research agent.")
+    parser.add_argument("query", type=str, help="The research query.")
+    args = parser.parse_args()
+
+    config = {"configurable": {}}
+    inputs = {"messages": [HumanMessage(content=args.query)]}
+    final_report = ""
+
+    async for event in deep_researcher.astream_events(inputs, config=config, version="v2"):
+        kind = event["event"]
+        if kind == "on_chain_end":
+            if event["name"] == "final_report_generation":
+                final_report = event["data"]["output"]["final_report"]
+                print("Final report generated.")
+                break
+
+    if final_report:
+        with open("final_report.md", "w") as f:
+            f.write(final_report)
+        print("Final report saved to final_report.md")
+    else:
+        print("Could not generate final report.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This PR introduces a new script, `run_research.py`, to allow for programmatic
  execution of the deep research agent from the command line. This is useful for
  automated workflows and for capturing the full, untruncated output of the final
   report.

**Changes:**
- `run_research.py`: A new script that takes a research query as a command-line
     argument and saves the generated report to final_report.md.
- `README.md`: Updated the "Deployments and Usages" section with instructions on
     how to use the new script.
- `.gitignore`: Added final_report.md to the .gitignore file to prevent
     generated reports from being accidentally committed.


**Usage:**
```
 python run_research.py "Your research query here"
 ```