### PR TITLE
Fix datetime import error in get_today_str function

### DIFF
--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -875,7 +875,7 @@ def get_today_str() -> str:
     Returns:
         Human-readable date string in format like 'Mon Jan 15, 2024'
     """
-    now = datetime.datetime.now()
+    now = datetime.now()
     return f"{now:%a} {now:%b} {now.day}, {now:%Y}"
 
 def get_config_value(value):


### PR DESCRIPTION
  This PR resolves an import error in the get_today_str function where datetime.datetime.now() was being used
  but only datetime was imported, causing a NameError.

  Changes:
   - Changed datetime.datetime.now() to datetime.now() in src/open_deep_research/utils.py

  Related Issue:
  This addresses a bug where the function would raise a NameError when called.

  Testing:
  The fix has been tested locally and resolves the import error.

  Please review and let me know if any changes are needed.