### PR TITLE
Feat: Make Tavily search timeout configurable

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -117,6 +117,18 @@ class Configuration(BaseModel):
             }
         }
     )
+    tavily_timeout: int = Field(
+        default=60,
+        metadata={
+            "x_oap_ui_config": {
+                "type": "number",
+                "default": 60,
+                "min": 1,
+                "max": 300,
+                "description": "Timeout for Tavily search in seconds."
+            }
+        }
+    )
     # Model Configuration
     summarization_model: str = Field(
         default="openai:gpt-4.1-mini",

--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -169,11 +169,12 @@ async def tavily_search_async(
     ]
     
     # Execute all search queries in parallel and return results
+    configurable = Configuration.from_runnable_config(config)
     try:
-        search_results = await asyncio.wait_for(asyncio.gather(*search_tasks), timeout=60.0)
+        search_results = await asyncio.wait_for(asyncio.gather(*search_tasks), timeout=configurable.tavily_timeout)
         return search_results
     except asyncio.TimeoutError:
-        logging.warning("Tavily search timed out after 60 seconds")
+        logging.warning(f"Tavily search timed out after {configurable.tavily_timeout} seconds")
         return []
 
 async def summarize_webpage(model: BaseChatModel, webpage_content: str) -> str:


### PR DESCRIPTION
 This PR makes the Tavily search timeout configurable, allowing users to adjust the timeout
  based on their needs and network conditions. This improves the robustness and reliability of
  the application by preventing it from hanging if the Tavily search API is slow or
  unresponsive.

  Changes:

   * Added a tavily_timeout field to the Configuration class with a default value of 60 seconds.
   * Used the tavily_timeout value from the configuration in the tavily_search_async function.