### PR TITLE
fix: AttributeError: type object 'datetime.datetime' has no attribute…

### DIFF
--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -875,7 +875,7 @@ def get_today_str() -> str:
     Returns:
         Human-readable date string in format like 'Mon Jan 15, 2024'
     """
-    now = datetime.datetime.now()
+    now = datetime.now()
     return f"{now:%a} {now:%b} {now.day}, {now:%Y}"
 
 def get_config_value(value):


### PR DESCRIPTION
In `src/open_deep_research/utils.py`：

```python
...
from datetime import datetime, timedelta, timezone
...
def get_today_str() -> str:
    """Get current date formatted for display in prompts and outputs.
    
    Returns:
        Human-readable date string in format like 'Mon Jan 15, 2024'
    """
    now = datetime.datetime.now()
    return f"{now:%a} {now:%b} {now.day}, {now:%Y}"
```
Since `from datetime import datetime` has already been executed, calling `get_today_str()` will trigger the following exception:
```
    datetime.datetime.now()
    ^^^^^^^^^^^^^^^^^
AttributeError: type object 'datetime.datetime' has no attribute 'datetime'
```