### PR TITLE
fix(supervisor_tools): remove stray `or True` that forces premature END

### DIFF
--- a/src/open_deep_research/deep_researcher.py
+++ b/src/open_deep_research/deep_researcher.py
@@ -331,7 +331,7 @@ async def supervisor_tools(state: SupervisorState, config: RunnableConfig) -> Co
                 
         except Exception as e:
             # Handle research execution errors
-            if is_token_limit_exceeded(e, configurable.research_model) or True:
+            if is_token_limit_exceeded(e, configurable.research_model):
                 # Token limit exceeded or other error - end research phase
                 return Command(
                     goto=END,


### PR DESCRIPTION
In the supervisor_tools except block:
`if is_token_limit_exceeded(e, configurable.research_model) or True:` The `or True` made the condition unconditional, ending research on any exception. Remove `or True` so only token-limit errors trigger END.