### PR TITLE
added open router support by adding openai_api_key and model provider…

### DIFF
--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -118,13 +118,35 @@ class Configuration(BaseModel):
         }
     )
     # Model Configuration
+    ### Adding endpoint URL
+    openai_api_base: str = Field(
+        default="https://api.openai.com/v1", # "https://openrouter.ai/api/v1" for Open Router
+        metadat={
+            "x_oap_ui_config" : {
+                "type": "text", 
+                "default" : "https://api.openai.com/v1", 
+                "description": "Endpoint for OpenAI API", 
+            }
+        }
+    )
+    ###
     summarization_model: str = Field(
-        default="openai:gpt-4.1-mini",
+        default="openai:gpt-4.1-mini", # "openai/gpt-4.1-mini" for Open Router
         metadata={
             "x_oap_ui_config": {
                 "type": "text",
                 "default": "openai:gpt-4.1-mini",
                 "description": "Model for summarizing research results from Tavily search results"
+            }
+        }
+    )
+    summarization_model_provider: str = Field(
+        default="openai", 
+        metadata={
+            "x_oap_ui_config": {
+                "type": "text",
+                "default": "openai", 
+                "description": "Model provider"
             }
         }
     )
@@ -151,12 +173,22 @@ class Configuration(BaseModel):
         }
     )
     research_model: str = Field(
-        default="openai:gpt-4.1",
+        default="openai:gpt-4.1", # "openai/gpt-4.1" for Open Router
         metadata={
             "x_oap_ui_config": {
                 "type": "text",
                 "default": "openai:gpt-4.1",
                 "description": "Model for conducting research. NOTE: Make sure your Researcher Model supports the selected search API."
+            }
+        }
+    )
+    research_model_provider: str = Field(
+        default="openai", 
+        metadata={
+            "x_oap_ui_config": {
+                "type": "text",
+                "default": "openai", 
+                "description": "Model provider"
             }
         }
     )
@@ -171,12 +203,22 @@ class Configuration(BaseModel):
         }
     )
     compression_model: str = Field(
-        default="openai:gpt-4.1",
+        default="openai:gpt-4.1", # "openai/gpt-4.1-mini" for Open Router
         metadata={
             "x_oap_ui_config": {
                 "type": "text",
                 "default": "openai:gpt-4.1",
                 "description": "Model for compressing research findings from sub-agents. NOTE: Make sure your Compression Model supports the selected search API."
+            }
+        }
+    )
+    compression_model_provider: str = Field(
+        default="openai", 
+        metadata={
+            "x_oap_ui_config": {
+                "type": "text",
+                "default": "openai", 
+                "description": "Model provider"
             }
         }
     )
@@ -191,12 +233,22 @@ class Configuration(BaseModel):
         }
     )
     final_report_model: str = Field(
-        default="openai:gpt-4.1",
+        default="openai:gpt-4.1", # "openai/gpt-4.1" for Open Router
         metadata={
             "x_oap_ui_config": {
                 "type": "text",
                 "default": "openai:gpt-4.1",
                 "description": "Model for writing the final report from all research findings"
+            }
+        }
+    )
+    final_report_model_provider: str = Field(
+        default="openai", 
+        metadata={
+            "x_oap_ui_config": {
+                "type": "text",
+                "default": "openai", 
+                "description": "Model provider"
             }
         }
     )

--- a/src/open_deep_research/deep_researcher.py
+++ b/src/open_deep_research/deep_researcher.py
@@ -54,7 +54,8 @@ from open_deep_research.utils import (
 
 # Initialize a configurable model that we will use throughout the agent
 configurable_model = init_chat_model(
-    configurable_fields=("model", "max_tokens", "api_key"),
+    configurable_fields=("model", "max_tokens", "api_key", 
+        "openai_api_base", "model_provider", )
 )
 
 async def clarify_with_user(state: AgentState, config: RunnableConfig) -> Command[Literal["write_research_brief", "__end__"]]:
@@ -82,7 +83,9 @@ async def clarify_with_user(state: AgentState, config: RunnableConfig) -> Comman
         "model": configurable.research_model,
         "max_tokens": configurable.research_model_max_tokens,
         "api_key": get_api_key_for_model(configurable.research_model, config),
-        "tags": ["langsmith:nostream"]
+        "tags": ["langsmith:nostream"], 
+        "openai_api_base": configurable.openai_api_base, 
+        "model_provider": configurable.research_model_provider, 
     }
     
     # Configure model with structured output and retry logic
@@ -135,7 +138,10 @@ async def write_research_brief(state: AgentState, config: RunnableConfig) -> Com
         "model": configurable.research_model,
         "max_tokens": configurable.research_model_max_tokens,
         "api_key": get_api_key_for_model(configurable.research_model, config),
-        "tags": ["langsmith:nostream"]
+        "tags": ["langsmith:nostream"], 
+        "openai_api_base" : configurable.openai_api_base, 
+        "model_provider": configurable.research_model_provider, 
+
     }
     
     # Configure model for structured research question generation
@@ -195,7 +201,9 @@ async def supervisor(state: SupervisorState, config: RunnableConfig) -> Command[
         "model": configurable.research_model,
         "max_tokens": configurable.research_model_max_tokens,
         "api_key": get_api_key_for_model(configurable.research_model, config),
-        "tags": ["langsmith:nostream"]
+        "tags": ["langsmith:nostream"], 
+        "openai_api_base" : configurable.openai_api_base,  
+        "model_provider": configurable.research_model_provider, 
     }
     
     # Available tools: research delegation, completion signaling, and strategic thinking
@@ -393,7 +401,9 @@ async def researcher(state: ResearcherState, config: RunnableConfig) -> Command[
         "model": configurable.research_model,
         "max_tokens": configurable.research_model_max_tokens,
         "api_key": get_api_key_for_model(configurable.research_model, config),
-        "tags": ["langsmith:nostream"]
+        "tags": ["langsmith:nostream"], 
+        "openai_api_base" : configurable.openai_api_base,  
+        "model_provider": configurable.research_model_provider, 
     }
     
     # Prepare system prompt with MCP context if available
@@ -628,7 +638,9 @@ async def final_report_generation(state: AgentState, config: RunnableConfig):
         "model": configurable.final_report_model,
         "max_tokens": configurable.final_report_model_max_tokens,
         "api_key": get_api_key_for_model(configurable.final_report_model, config),
-        "tags": ["langsmith:nostream"]
+        "tags": ["langsmith:nostream"], 
+        "openai_api_base" : configurable.openai_api_base,  
+        "model_provider": configurable.final_report_model_provider, 
     }
     
     # Step 3: Attempt report generation with token limit retry logic

--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -86,8 +86,8 @@ async def tavily_search(
     summarization_model = init_chat_model(
         model=configurable.summarization_model,
         max_tokens=configurable.summarization_model_max_tokens,
-        api_key=model_api_key,
-        tags=["langsmith:nostream"]
+        openai_api_base=configurable.openai_api_base, 
+        model_provider=configurable.summarization_model_provider, 
     ).with_structured_output(Summary).with_retry(
         stop_after_attempt=configurable.max_structured_output_retries
     )


### PR DESCRIPTION
This update makes the code compatible with Open Router or other cases where the Open AI API Endpoint URL needs to be changed in a simple way:
- A configurable openai_api_base parameter is added (default is still the original Open AI API URL: https://api.openai.com/v1 but can be changed to 'https://openrouter.ai/api/v1' for Open Router, for example.
- Configurable research_model_provider, summary_model_provider, compression_model_provider, final_report_model_provider: all default to 'openai', doesn't need to be changed for Open Router (these were needed because otherwise init_chat_model can't infer the provider for models that are not from OpenAI).

When using OpenRouter, obviously the models can now also be changed to any model in Open Router (e.g. meta-llama/llama-4-maverick, etc). Be aware that the names may change slightly between OpenAI and Open Router: e.g. openai:gpt-4.1-mini -> openai/gpt-4.1-mini.

These can all be changed now via the LangSmith UI too.