### PR TITLE
Enhance the verification of the logic that involves the use of think_tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ SUPABASE_KEY=
 SUPABASE_URL=
 # Should be set to true for a production deployment on Open Agent Platform. Should be set to false otherwise, such as for local development.
 GET_API_KEYS_FROM_CONFIG=false
+
+# Setting it to true ensures that the think_tool tool can execute correctly. Otherwise, there is a very small probability that it will not be executed.
+FORCE_THINK_TOOL=False

--- a/src/open_deep_research/configuration.py
+++ b/src/open_deep_research/configuration.py
@@ -39,6 +39,16 @@ class Configuration(BaseModel):
     """Main configuration class for the Deep Research agent."""
     
     # General Configuration
+    force_think_tool: bool = Field(
+        default=False,
+        metadata={
+            "x_oap_ui_config": {
+                "type": "boolean",
+                "default": False,
+                "description": "Require agents to call think_tool before executing other tools"
+            }
+        }
+    )
     max_structured_output_retries: int = Field(
         default=3,
         metadata={

--- a/src/open_deep_research/prompts.py
+++ b/src/open_deep_research/prompts.py
@@ -366,3 +366,24 @@ Remember, your goal is to create a summary that can be easily understood and uti
 
 Today's date is {date}.
 """
+
+
+
+force_think_tool_supervisor_before_conduct_research_reminder = (
+    "Before delegating any research with ConductResearch you must first call think_tool to "
+    "plan your approach. Reflect with think_tool, then decide whether to delegate."
+)
+
+force_think_tool_supervisor_after_conduct_research_reminder = (
+    "After calling ConductResearch, you must call think_tool to reflect on the results. "
+    "Use think_tool now to analyze progress and plan the next action."
+)
+
+force_think_tool_researcher_after_call_search_tool_reminder = (
+    "You must call think_tool to reflect on the latest findings before using other tools. "
+    "Use think_tool now to analyze progress and plan the next action."
+)
+
+has_mixed_think_tool_calls_reminder = (
+    "You cannot call think_tool in parallel with other tools. Please call think_tool first, then call the other tools."
+)


### PR DESCRIPTION
## Background
Since the invocation of the think_tool is requested through prompts, there is a possibility that the agent may bypass the invocation of think_tool. This modification is aimed at enhancing the stability of the invocation of think_tool.

## Modified
Enhance the verification of the logic that involves the use of think_tool and add FORCE_THINK_TOOL configuration and related reminders

- Introduced `FORCE_THINK_TOOL` environment variable to enforce reflection before tool execution.
- Enhanced `deep_researcher.py` and `supervisor_tools` logic to check for correct tool call order.
- Added reminders for supervisors and researchers regarding the use of `think_tool` in conjunction with other tools.
- Implemented utility functions to check for mixed tool calls and retrieve previous tool names.

## sreenshot

1. Parallel invocation of think_tool and other tools
<img width="1031" height="897" alt="image" src="https://github.com/user-attachments/assets/61154fad-52bf-4966-b5f8-1bf38b11b238" />

2. Before invoking the ConductSearch tool, the think_tool was not invoked.
<img width="945" height="970" alt="image" src="https://github.com/user-attachments/assets/ad96a740-d3b5-4eea-9844-9479b2fa15ce" />

