### PR TITLE
Fix message truncation logic in token limit retry handler

### DIFF
--- a/src/open_deep_research/utils.py
+++ b/src/open_deep_research/utils.py
@@ -860,7 +860,7 @@ def remove_up_to_last_ai_message(messages: list[MessageLikeRepresentation]) -> l
     for i in range(len(messages) - 1, -1, -1):
         if isinstance(messages[i], AIMessage):
             # Return everything up to (but not including) the last AI message
-            return messages[:i]
+            return messages[i:]
     
     # No AI messages found, return original list
     return messages


### PR DESCRIPTION
Update remove_up_to_last_ai_message to correctly slice the message history when compressing research findings exceeds the model context window.