### PR TITLE
Add agent observability with Monocle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ LANGSMITH_API_KEY=
 LANGSMITH_PROJECT=
 LANGSMITH_TRACING=
 
+# Optional Monocle observability (opt-in; requires the extra: pip install "open_deep_research[monocle]").
+MONOCLE_TRACING=false           # set to true to enable
+MONOCLE_EXPORTERS=file          # file, console, okahu, s3, blob, gcs (default: file)
+OKAHU_API_KEY=okh_xxxxxxxx      # required only for the `okahu` exporter
+
 # Only necessary for Open Agent Platform
 SUPABASE_KEY=
 SUPABASE_URL=

--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ Open Deep Research supports a wide range of search tools. By default it uses the
 
 See the fields in the [configuration.py](https://github.com/langchain-ai/open_deep_research/blob/main/src/open_deep_research/configuration.py) for various other settings to customize the behavior of Open Deep Research. 
 
+#### Monocle Tracing
+
+Open Deep Research also supports [Monocle](https://github.com/monocle2ai/monocle), an OpenTelemetry-based tracer for agentic applications. It records each run end-to-end: LLM calls, agent steps, and tool invocations, with inputs, outputs, timings, and token counts.
+
+Install the optional extra and add the following to your `.env` file:
+
+```bash
+pip install "open_deep_research[monocle]"
+```
+
+```bash
+MONOCLE_TRACING=true
+MONOCLE_EXPORTERS=file          # file, console, okahu, s3, blob, gcs (default: file)
+OKAHU_API_KEY=okh_xxxxxxxx      # required only for the `okahu` exporter
+```
+
+Each run writes one trace file to `.monocle/`; open it in the [Monocle VS Code extension](https://marketplace.visualstudio.com/items?itemName=OkahuAI.monocle-apptrace). Connect to [Okahu](https://www.okahu.ai) to analyze traces across runs (via the `okahu` exporter).
+
 ### 📊 Evaluation
 
 Open Deep Research is configured for evaluation with [Deep Research Bench](https://huggingface.co/spaces/Ayanami0730/DeepResearch-Leaderboard). This benchmark has 100 PhD-level research tasks (50 English, 50 Chinese), crafted by domain experts across 22 fields (e.g., Science & Tech, Business & Finance) to mirror real-world deep-research needs. It has 2 evaluation metrics, but the leaderboard is based on the RACE score. This uses LLM-as-a-judge (Gemini) to evaluate research reports against a golden set of reports compiled by experts across a set of metrics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["mypy>=1.11.1", "ruff>=0.6.1"]
+monocle = ["monocle_apptrace"]
 
 [build-system]
 requires = ["setuptools>=73.0.0", "wheel"]

--- a/src/open_deep_research/deep_researcher.py
+++ b/src/open_deep_research/deep_researcher.py
@@ -1,6 +1,7 @@
 """Main LangGraph implementation for the Deep Research agent."""
 
 import asyncio
+import os
 from typing import Literal
 
 from langchain.chat_models import init_chat_model
@@ -51,6 +52,33 @@ from open_deep_research.utils import (
     remove_up_to_last_ai_message,
     think_tool,
 )
+
+def _setup_monocle_tracing() -> None:
+    """Optional Monocle observability, gated by MONOCLE_TRACING (see .env.example). No-op when off."""
+    if os.getenv("MONOCLE_TRACING", "").strip().lower() not in ("1", "true", "yes", "on"):
+        return
+    allowed = ("file", "console", "okahu", "s3", "blob", "gcs")
+    # App owns MONOCLE_EXPORTERS: validate here so a typo fails fast, then forward as-is.
+    exporters = os.getenv("MONOCLE_EXPORTERS", "").strip() or "file"
+    selected = [e.strip() for e in exporters.split(",") if e.strip()]
+    unknown = [e for e in selected if e not in allowed]
+    if unknown:
+        raise ValueError(
+            f"MONOCLE_EXPORTERS has unknown exporter(s): {', '.join(unknown)}. Allowed: {', '.join(allowed)}."
+        )
+    if "okahu" in selected and not os.getenv("OKAHU_API_KEY"):
+        raise ValueError("Monocle 'okahu' exporter is selected but OKAHU_API_KEY is not set.")
+    try:
+        from monocle_apptrace import setup_monocle_telemetry
+    except ImportError as exc:
+        raise RuntimeError(
+            "MONOCLE_TRACING is enabled but monocle_apptrace is not installed. "
+            'Install the \'monocle\' extra: pip install "open_deep_research[monocle]".'
+        ) from exc
+    setup_monocle_telemetry(workflow_name="open-deep-research", monocle_exporters_list=exporters)
+
+
+_setup_monocle_tracing()
 
 # Initialize a configurable model that we will use throughout the agent
 configurable_model = init_chat_model(


### PR DESCRIPTION
## Summary

Adds Monocle observability to the agent. Monocle is an OpenTelemetry-based tracer for LLM applications. With it enabled, each run is recorded as a structured trace: the agent and graph invocations, tool calls, LLM inferences, token usage, and timings. The change is additive and does not alter application logic.

## What this adds

Instrumentation is one setup call plus one dependency:

- `pyproject.toml`: adds `monocle_apptrace`.
- `src/open_deep_research/deep_researcher.py`: calls `setup_monocle_telemetry(workflow_name="open-deep-research", monocle_exporters_list="file")` at startup.

That call auto-instruments the frameworks already in use (LangGraph and the LLM clients), so there is no per-tool or per-call wiring to maintain. Traces are written to `.monocle/` by default.

## What you get

Each run produces a trace of all the agents that were triggered and the LLM inferences they made. In effect, it's the path the run took to answer the question. This is useful for developers building the agent, since they can see how it actually behaved on a run. The same traces are also a good basis for a behavioral test suite, an integration test that asserts on that behavior, and I've opened a companion PR that shows how that works: [behavioral test suite](https://github.com/langchain-ai/open_deep_research/pull/288). You can open the trace files directly, view them in the [Monocle VS Code extension](https://marketplace.visualstudio.com/items?itemName=OkahuAI.monocle-apptrace), or send them to [Okahu](https://www.okahu.ai) for analysis across many runs.


---

## Example trace (Okahu VS Code Extension)

The open_deep_research LangGraph workflow, with the researcher agent and its OpenAI-native web search captured as trace spans.

<img width="1710" height="1070" alt="image" src="https://github.com/user-attachments/assets/dcaab815-82ef-4526-b661-ca07813fc3fc" />





---

PS: if Monocle looks useful, a ⭐ helps the project (https://github.com/monocle2ai/monocle). And if you want to turn these traces into tests, that's the companion PR (#288).
